### PR TITLE
feat(api): modify CR in Income and Expense

### DIFF
--- a/express/src/controllers/authController.js
+++ b/express/src/controllers/authController.js
@@ -14,7 +14,7 @@ import { generateVerificationToken, verificationContent } from "../utils/verific
  * @access  Public
  */
 export const register = async (req, res) => {
-    const { nickname, email, password, confirmPassword, phone } = req.body;
+    const { nickname, email, password, confirmPassword } = req.body;
 
     if (password !== confirmPassword) {
         return res.status(400).json({ message: "Passwords do not match" });
@@ -29,10 +29,9 @@ export const register = async (req, res) => {
                 return res.status(400).json({ message: "Email already exists" });
             }
             user.nickname = nickname;
-            user.phone = phone;
         } else {
             // New user
-            user = new User({ nickname, email, phone });
+            user = new User({ nickname, email });
             isNewUser = true;
         }
 

--- a/express/src/controllers/contactController.js
+++ b/express/src/controllers/contactController.js
@@ -18,8 +18,7 @@ export const submitContactForm = async (req, res, next) => {
             "New Contact Us Submission",
             `<p>Name: ${contact.name || ""}<br/>
                 Email: ${contact.email}<br/>
-                Phone: ${contact.phone || ""}<br/>
-                Description: ${contact.description || ""}</p>`
+                Note: ${contact.note || ""}</p>`
         );
         res.status(201).json({ message: "Contact submitted", contact });
     } catch (err) {

--- a/express/src/middlewares/authMiddleware.js
+++ b/express/src/middlewares/authMiddleware.js
@@ -84,6 +84,12 @@ export async function attachAccount(req, res, next) {
                 });
             }
             req.account = account;
+        } else if (req.userId && !req.account) {
+            let account = await Account.findById(req.accountId);
+            if (!account) {
+                return res.status(401).json({ message: "Account not found" });
+            }
+            req.account = account;
         }
         next();
     } catch (err) {

--- a/express/src/middlewares/validate.js
+++ b/express/src/middlewares/validate.js
@@ -14,12 +14,17 @@ const validate =
     (schema, type = "body") =>
     (req, res, next) => {
         const data = req[type]; // type can be "body", "query", "params"
-        const { error } = schema.validate(data, { abortEarly: false });
+        const { error, value } = schema.validate(data, { abortEarly: false });
 
         if (error) {
             const messages = error.details.map((detail) => detail.message);
             return res.status(400).json({ errors: messages });
         }
+
+        // Attach validated data for controller use
+        if (type === "body") req.validatedBody = value;
+        if (type === "query") req.validatedQuery = value;
+        if (type === "params") req.validatedParams = value;
 
         next();
     };

--- a/express/src/models/Expense.js
+++ b/express/src/models/Expense.js
@@ -9,25 +9,41 @@ const expenseSchema = new mongoose.Schema(
             required: true,
             index: true,
         },
-        name: { type: String, required: true, minlength: 3 },
         date: { type: Date, default: Date.now, index: true },
         category: {
             type: String,
             enum: [
-                "Groceries",
-                "Gas",
+                "Food & Drink",
+                "Shopping",
+                "Transport",
+                "Home",
+                "Bills & Fees",
                 "Entertainment",
-                "Bills",
-                "Rent",
-                "Utilities",
-                "Food",
+                "Groceries",
+                "Car",
+                "Travel",
+                "Family & Personal",
+                "Healthcare",
                 "Other",
             ],
             required: true,
             index: true,
         },
+        customCategory: {
+            type: String,
+            trim: true,
+            required: function () {
+                return this.category === "Other";
+            },
+        },
         amount: { type: Number, required: true, min: 0 },
-        description: { type: String, default: "", trim: true },
+        note: {
+            type: String,
+            trim: true,
+            required: function () {
+                return this.category === "Other";
+            },
+        },
         isRecurring: { type: Boolean, default: false },
     },
     { timestamps: true }

--- a/express/src/models/Income.js
+++ b/express/src/models/Income.js
@@ -9,16 +9,37 @@ const incomeSchema = new mongoose.Schema(
             required: true,
             index: true,
         },
-        name: { type: String, required: true, minlength: 3 },
         date: { type: Date, default: Date.now, index: true },
         category: {
             type: String,
-            enum: ["Pay", "Gift", "Other"],
+            enum: [
+                "Salary",
+                "Business",
+                "Gift",
+                "Extra Income",
+                "Loan",
+                "Parental Leave",
+                "Insurance Payout",
+                "Other",
+            ],
             required: true,
             index: true,
         },
+        customCategory: {
+            type: String,
+            trim: true,
+            required: function () {
+                return this.category === "Other";
+            },
+        },
         amount: { type: Number, required: true, min: 0 },
-        description: { type: String, default: "", trim: true },
+        note: {
+            type: String,
+            trim: true,
+            required: function () {
+                return this.category === "Other";
+            },
+        },
         isRecurring: { type: Boolean, default: false },
     },
     { timestamps: true }

--- a/express/src/routes/expenseRoutes.js
+++ b/express/src/routes/expenseRoutes.js
@@ -8,35 +8,30 @@ import {
     getExpensesByQuery,
     updateExpense,
 } from "../controllers/expenseController.js";
-import {
-    attachAccount,
-    ensureAuthenticated,
-    optionalJwt,
-    protect,
-} from "../middlewares/authMiddleware.js";
-import validate from "../middlewares/validate.js";
+import { attachAccount, authAny, optionalJwt } from "../middlewares/authMiddleware.js";
+import { validateBody, validateQuery } from "../middlewares/validate.js";
 import { expenseSchema, updateExpenseSchema } from "../validations/expenseValidation.js";
 import { expenseQuerySchema } from "../validations/queryValidation.js";
 
 const router = express.Router();
 
 // Authentication middleware - protects all routes
-router.use(ensureAuthenticated, attachAccount);
+router.use(optionalJwt, authAny, attachAccount);
 
 // Create expenditure
-router.post("/", validate(expenseSchema), createExpense);
+router.post("/", validateBody(expenseSchema), createExpense);
 
 // Get all expenditures (no filtering)
 router.get("/", getExpenses);
 
 // Get expenses based on filter criteria (e.g. filter by category, year, month)
-router.get("/filter", validate(expenseQuerySchema), getExpensesByQuery);
+router.get("/filter", validateQuery(expenseQuerySchema), getExpensesByQuery);
 
 // Get a single expense based on the expense ID
 router.get("/:id", getExpense);
 
 // Update expenditure
-router.patch("/:id", validate(updateExpenseSchema), updateExpense);
+router.patch("/:id", validateBody(updateExpenseSchema), updateExpense);
 
 // Delete expenses
 router.delete("/:id", deleteExpense);

--- a/express/src/routes/incomeRoutes.js
+++ b/express/src/routes/incomeRoutes.js
@@ -9,29 +9,29 @@ import {
     getIncomesByQuery,
     updateIncome,
 } from "../controllers/incomeController.js";
-import { attachAccount, ensureAuthenticated } from "../middlewares/authMiddleware.js";
-import validate from "../middlewares/validate.js";
+import { attachAccount, authAny, optionalJwt } from "../middlewares/authMiddleware.js";
+import { validateBody, validateQuery } from "../middlewares/validate.js";
 import { incomeSchema, updateIncomeSchema } from "../validations/incomeValidation.js";
 import { incomeQuerySchema } from "../validations/queryValidation.js";
 
 const router = express.Router();
 
-router.use(ensureAuthenticated, attachAccount);
+router.use(optionalJwt, authAny, attachAccount);
 
 // POST create income
-router.post("/", validate(incomeSchema), createIncome);
+router.post("/", validateBody(incomeSchema), createIncome);
 
 // GET Get all income based on account ID
 router.get("/", getIncomes);
 
 // GET to get filtered revenue (filtered by category and time range)
-router.get("/filter", validate(incomeQuerySchema, "query"), getIncomesByQuery);
+router.get("/filter", validateQuery(incomeQuerySchema), getIncomesByQuery);
 
 // GET Get a single income based on income ID
 router.get("/:id", getIncome);
 
 // PATCH update income
-router.patch("/:id", validate(updateIncomeSchema), updateIncome);
+router.patch("/:id", validateBody(updateIncomeSchema), updateIncome);
 
 // DELETE delete income
 router.delete("/:id", deleteIncome);

--- a/express/src/validations/expenseValidation.js
+++ b/express/src/validations/expenseValidation.js
@@ -2,35 +2,61 @@
 import Joi from "joi";
 
 const expenseCategories = [
-    "Groceries",
-    "Gas",
+    "Food & Drink",
+    "Shopping",
+    "Transport",
+    "Home",
+    "Bills & Fees",
     "Entertainment",
-    "Bills",
-    "Rent",
-    "Utilities",
-    "Food",
+    "Groceries",
+    "Car",
+    "Travel",
+    "Family & Personal",
+    "Healthcare",
     "Other",
 ];
 
 // Joi schema for expense validation
 export const expenseSchema = Joi.object({
-    name: Joi.string().min(3).required(),
     date: Joi.date().required(),
     category: Joi.string()
         .valid(...expenseCategories)
         .required(),
     amount: Joi.number().min(0).required(),
-    description: Joi.string().optional(),
+    customCategory: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().min(1).required(),
+        otherwise: Joi.forbidden(),
+    }),
+    note: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().trim().min(1).required().messages({
+            "any.required": "Note is required when category is 'Other'",
+            "string.empty": "Note is required when category is 'Other'",
+        }),
+        otherwise: Joi.string().allow("", null).optional(),
+    }),
     isRecurring: Joi.boolean().default(false),
 });
 
 export const updateExpenseSchema = Joi.object({
-    name: Joi.string().min(3).optional(),
     date: Joi.date().optional(),
     category: Joi.string()
         .valid(...expenseCategories)
         .optional(),
     amount: Joi.number().min(0).optional(),
-    description: Joi.string().optional(),
+    customCategory: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().min(1).required(),
+        otherwise: Joi.forbidden(),
+    }),
+    note: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().trim().min(1).required().messages({
+            "any.required": "Note is required when category is 'Other'",
+            "string.empty": "Note is required when category is 'Other'",
+        }),
+        otherwise: Joi.string().allow("", null).optional(),
+    }),
     isRecurring: Joi.boolean().optional(),
 });

--- a/express/src/validations/incomeValidation.js
+++ b/express/src/validations/incomeValidation.js
@@ -1,27 +1,58 @@
 // src/validations/incomeValidation.js
 import Joi from "joi";
 
-const incomeCategories = ["Pay", "Gift", "Other"];
+const incomeCategories = [
+    "Salary",
+    "Business",
+    "Gift",
+    "Extra Income",
+    "Loan",
+    "Parental Leave",
+    "Insurance Payout",
+    "Other",
+];
 
 // Joi schema for income validation
 export const incomeSchema = Joi.object({
-    name: Joi.string().min(3).required(),
     date: Joi.date().required(),
     category: Joi.string()
         .valid(...incomeCategories)
         .required(),
     amount: Joi.number().min(0).required(),
-    description: Joi.string().optional(),
+    customCategory: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().min(1).required(),
+        otherwise: Joi.forbidden(),
+    }),
+    note: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().trim().min(1).required().messages({
+            "any.required": "Note is required when category is 'Other'",
+            "string.empty": "Note is required when category is 'Other'",
+        }),
+        otherwise: Joi.string().allow("", null).optional(),
+    }),
     isRecurring: Joi.boolean().default(false),
 });
 
 export const updateIncomeSchema = Joi.object({
-    name: Joi.string().min(3).optional(),
     date: Joi.date().optional(),
     category: Joi.string()
         .valid(...incomeCategories)
         .optional(),
     amount: Joi.number().min(0).optional(),
-    description: Joi.string().optional(),
+    customCategory: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().min(1).required(),
+        otherwise: Joi.forbidden(),
+    }),
+    note: Joi.string().when("category", {
+        is: "Other",
+        then: Joi.string().trim().min(1).required().messages({
+            "any.required": "Note is required when category is 'Other'",
+            "string.empty": "Note is required when category is 'Other'",
+        }),
+        otherwise: Joi.string().allow("", null).optional(),
+    }),
     isRecurring: Joi.boolean().optional(),
 });


### PR DESCRIPTION
### Summary

This pull request refactors the `description` field to `note` in both the Expense and Income models and controllers. It also enforces that the `note` field is required when the `category` is set to `"Other"`. Additional validation logic has been added to both the schema and controller layers to ensure data integrity and provide clear error messages to API consumers.

### Changes

1. Add customCategory if category is `Other`.
2. Modify `createIncome`, `updateIncome`, `createExpense`, `updateExpense`.
3. Use `authAny` instead of `ensureAuthenticated`.
4. Modify `incomeValidation` and `expenseValidation` to match new UI design.
5. Renamed the `description` field to `note` in all relevant models, controllers, and API documentation.
6. Added conditional required validation for the `note` field:  
  - When `category` is `"Other"`, `note` is required.
  - In other categories, `note` is optional.
7. Updated controller logic to provide user-friendly error messages when the required `note` is missing.
8. Added/updated tests for both Expense and Income create (POST) and update (PUT) endpoints to cover cases where `category` is `"Other"` and `note` is missing or present.
9. Delete `phone` in the API for registeration.
10. Add more enum in models and validations.

### Testing

1. Verified that creating or updating an Expense or Income with `category: "Other"` and no `note` returns a `400 Bad Request` with an appropriate error message.
2. Confirmed that requests with other categories succeed even if `note` is omitted.
3. Ensured that all existing and new tests pass.
